### PR TITLE
Add fix to mf18 routing bug

### DIFF
--- a/packages/apps/dashboard/src/bootstrap.tsx
+++ b/packages/apps/dashboard/src/bootstrap.tsx
@@ -1,6 +1,6 @@
-import ReactDOM from "react-dom";
-import { App } from "./components/App";
-import { createMemoryHistory } from "history";
+import { createMemoryHistory } from 'history';
+import ReactDOM from 'react-dom';
+import { App } from './components/App';
 
 export const mount: MountFn = (el, params) => {
   const history = createMemoryHistory({
@@ -8,7 +8,7 @@ export const mount: MountFn = (el, params) => {
   });
 
   const listener = (location: unknown) => {
-    console.log("Mount Dashboard - onNavigate", location);
+    console.log('Mount Dashboard - onNavigate', location);
     params.onNavigate(location);
   };
 
@@ -18,7 +18,7 @@ export const mount: MountFn = (el, params) => {
   return {
     onParentNavigate({ pathname: nextPathname }) {
       if (history.location.pathname !== nextPathname) {
-        console.log({ "Mount Dashboar - onParentnavigate": nextPathname });
+        console.log({ 'Mount Dashboard - onParentNavigate': nextPathname });
         history.push(nextPathname);
       }
     },


### PR DESCRIPTION
#### Key changes:

- Add a variable to track the `location.pathname` outside the React lifecycle

#### Reasoning

Bug was caused because the `location.pathname` wasn't being update in the `onNavigate()` function, thus the value was never changing from the initialPath, `/dashboard`, inside the `useMount()` hook.

Originally I looked at adding `location.pathname` to the array dependencies on the `useEffect()`, but this causes issues with when navigating to any of the sub-routes. This error still happened when externalizing the `onNavigate()` to a function or `useCallback()` outside the `useEffect()`.

---

While this solution is more an anti-pattern for React, I think it's the best approach that can be taken, especially given that:
- This is a temporary solution while we have apps running different major versions of React
- There is minimal changes to the current code (less refactoring for other teams)